### PR TITLE
Use MarshalIndent instead of marshalling and then indenting the code

### DIFF
--- a/util.go
+++ b/util.go
@@ -77,9 +77,7 @@ func completeTemplate(filePath string, data interface{}) (result template.HTML) 
 			t := time.Unix(epoch, 0)
 			return t.Format("02/01/2006 [15:04]")
 		},
-		"toTitleCase": func(text string) string {
-			return strings.Title(text)
-		},
+		"toTitleCase": strings.Title,
 	}).Parse(string(htmlTemplate))
 	if err != nil {
 		fmt.Println(err)

--- a/util.go
+++ b/util.go
@@ -98,17 +98,9 @@ func completeTemplate(filePath string, data interface{}) (result template.HTML) 
 
 // Convert a target object into a JSON string.
 func toJSON(target interface{}) (JSON string, err error) {
-	jsonResponse, err := json.Marshal(target)
+	jsonResponse, err := json.MarshalIndent(target, "", "\t")
 	if err != nil {
 		return
 	}
-
-	// pretty print JSON response - if this fails, return original unprettified JSON
-	indentBuffer := &bytes.Buffer{}
-	if err = json.Indent(indentBuffer, jsonResponse, "", "\t"); err != nil {
-		return
-	}
-	jsonResponse = indentBuffer.Bytes()
-
 	return string(jsonResponse), nil
 }


### PR DESCRIPTION
This simplifies the code a little and a call to MarshalIndent will do basically the same thing as this implementation :smiley_cat: 
https://github.com/golang/go/blob/master/src/encoding/json/encode.go#L169